### PR TITLE
fix: show selected lens with checkmark

### DIFF
--- a/Capture/Lenses/LensPicker.swift
+++ b/Capture/Lenses/LensPicker.swift
@@ -14,7 +14,15 @@ struct LensPicker: View {
                     self.lens = lens
                     dismiss()
                 } label: {
-                    Text("\(lens.make) \(lens.model)")
+                    HStack {
+                        Text("\(lens.make) \(lens.model)")
+                        
+                        Spacer()
+                        
+                        if lens == self.lens {
+                            Image(systemName: "checkmark")
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix lens picker view to show checkmark against selected lens.

![image](https://github.com/Oliver-Binns/capture/assets/5354593/561fc5d6-6bf7-417b-9b02-4ddb4b1bf5f0)
